### PR TITLE
セクションに動きとスタイリッシュな画像を追加

### DIFF
--- a/images/about.svg
+++ b/images/about.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#7f8c8d'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>About</text>
+</svg>

--- a/images/beer1.svg
+++ b/images/beer1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#f1c40f'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Pilsner</text>
+</svg>

--- a/images/beer2.svg
+++ b/images/beer2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#e74c3c'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>IPA</text>
+</svg>

--- a/images/beer3.svg
+++ b/images/beer3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#1abc9c'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Ale</text>
+</svg>

--- a/images/brewer.svg
+++ b/images/brewer.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#e67e22'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Brewer</text>
+</svg>

--- a/images/feature-hop.svg
+++ b/images/feature-hop.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#2ecc71'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Hop</text>
+</svg>

--- a/images/feature-limited.svg
+++ b/images/feature-limited.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#9b59b6'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Limited</text>
+</svg>

--- a/images/feature-water.svg
+++ b/images/feature-water.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#3498db'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Water</text>
+</svg>

--- a/images/order.svg
+++ b/images/order.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#d35400'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Order</text>
+</svg>

--- a/images/reviewers.svg
+++ b/images/reviewers.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+  <rect width='800' height='600' fill='#34495e'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='#ffffff' font-family='Arial'>Voices</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -18,23 +18,29 @@
   <img src="images/girl_beer.png" alt="ビールを飲む女の子" class="fixed-illust" id="illust">
 
   <section id="about" class="section fade-in">
-    <div class="container">
-      <h2>霧の谷とは</h2>
-      <p>山々に囲まれた霧の谷は、朝霧と湧き水に恵まれた地域です。澄んだ水と地元農家が育てたホップを使い、小さな醸造所で手作業のビール造りを行っています。</p>
+    <div class="container about">
+      <img src="images/about.svg" alt="霧の谷の風景" class="about-img fade-in">
+      <div class="about-text">
+        <h2>霧の谷とは</h2>
+        <p>山々に囲まれた霧の谷は、朝霧と湧き水に恵まれた地域です。澄んだ水と地元農家が育てたホップを使い、小さな醸造所で手作業のビール造りを行っています。</p>
+      </div>
     </div>
   </section>
 
   <section id="features" class="section fade-in">
     <div class="container features">
       <div class="feature fade-in">
+        <img src="images/feature-water.svg" alt="天然水仕込み">
         <h3>天然水仕込み</h3>
         <p>谷の地下から湧き出る天然水が、透明感のある味わいを生み出します。</p>
       </div>
       <div class="feature fade-in">
+        <img src="images/feature-hop.svg" alt="地元産ホップ">
         <h3>地元産ホップ</h3>
         <p>フレッシュな香りが広がる、地元農家が丹精込めて育てたホップ。</p>
       </div>
       <div class="feature fade-in">
+        <img src="images/feature-limited.svg" alt="限定醸造">
         <h3>限定醸造</h3>
         <p>少量生産でしか味わえない特別なビールをお届けします。</p>
       </div>
@@ -43,7 +49,7 @@
 
   <section id="brewer" class="section fade-in">
     <div class="container brewer">
-      <img src="images/brewer.jpg" alt="霧の谷ブルワー" class="brewer-photo">
+      <img src="images/brewer.svg" alt="霧の谷ブルワー" class="brewer-photo">
       <div class="brewer-text">
         <h2>職人のこだわり</h2>
         <p>霧の谷ブルワリーを立ち上げた佐藤健一は、地元の水と農産物を活かしたクラフトビール造りに情熱を注いでいます。小規模だからこそ、一つ一つの工程に目を配り、丁寧に仕上げています。</p>
@@ -56,17 +62,17 @@
       <h2>商品ラインナップ</h2>
       <div class="cards">
         <div class="card">
-          <img src="images/beer1.jpg" alt="霧の谷ピルスナー">
+            <img src="images/beer1.svg" alt="霧の谷ピルスナー">
           <h3>霧の谷ピルスナー</h3>
           <p>爽やかな喉ごしとクリアな後味。</p>
         </div>
         <div class="card">
-          <img src="images/beer2.jpg" alt="霧の谷IPA">
+            <img src="images/beer2.svg" alt="霧の谷IPA">
           <h3>霧の谷IPA</h3>
           <p>華やかなホップ香りと深い苦味。</p>
         </div>
         <div class="card">
-          <img src="images/beer3.jpg" alt="霧の谷エール">
+            <img src="images/beer3.svg" alt="霧の谷エール">
           <h3>霧の谷エール</h3>
           <p>コクのある麦の甘みとまろやかさ。</p>
         </div>
@@ -75,9 +81,10 @@
   </section>
 
   <section id="voice" class="section fade-in">
-    <div class="container">
-      <h2>お客様の声</h2>
-      <div class="reviews">
+      <div class="container">
+        <h2>お客様の声</h2>
+        <img src="images/reviewers.svg" alt="笑顔のお客様" class="reviews-photo fade-in">
+        <div class="reviews">
         <blockquote>
           「今まで飲んだ中で一番フレッシュ！自然の恵みを感じます。」  
           <cite>- 東京都 30代 男性</cite>
@@ -90,23 +97,24 @@
     </div>
   </section>
 
-  <section id="access" class="section fade-in">
-  <div class="container">
-    <h2>霧の谷へのアクセス</h2>
-    <p>東京から電車で2時間。自然豊かな観光地としても人気です。ビール工房の見学も可能です。</p>
-    <iframe src="https://www.google.com/maps/embed?pb=...（仮）" width="100%" height="300" style="border:0;" allowfullscreen></iframe>
-  </div>
-  </section>
-
-  <section id="order" class="section cta fade-in">
-    <div class="container order-layout">
-      <div class="order-text">
-        <h2>お取り寄せ</h2>
-        <p>霧の谷クラフトビールはオンラインで数量限定販売中です。お早めにご注文ください。</p>
-        <a href="#" class="btn">注文する</a>
+    <section id="access" class="section fade-in">
+      <div class="container">
+        <h2>霧の谷へのアクセス</h2>
+        <p>東京から電車で2時間。自然豊かな観光地としても人気です。ビール工房の見学も可能です。</p>
+        <iframe src="https://www.google.com/maps/embed?pb=...（仮）" width="100%" height="300" style="border:0;" allowfullscreen></iframe>
       </div>
-    </div>
-  </section>
+    </section>
+
+    <section id="order" class="section cta fade-in">
+      <div class="container order-layout">
+        <img src="images/order.svg" alt="オンライン注文" class="order-img fade-in">
+        <div class="order-text">
+          <h2>お取り寄せ</h2>
+          <p>霧の谷クラフトビールはオンラインで数量限定販売中です。お早めにご注文ください。</p>
+          <a href="#" class="btn">注文する</a>
+        </div>
+      </div>
+    </section>
 
 
   <footer class="footer fade-in">

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,16 @@ body {
   color: #333;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+:root {
+  --accent: #ff6b6b;
+  --accent-dark: #ff4757;
+}
+
 .container {
   width: 90%;
   max-width: 1100px;
@@ -19,6 +29,16 @@ h2 {
   font-size: 2.4rem;
   margin-bottom: 40px;
   text-align: center;
+  position: relative;
+}
+
+h2::after {
+  content: "";
+  display: block;
+  width: 60px;
+  height: 3px;
+  background: var(--accent);
+  margin: 10px auto 0;
 }
 
 .hero {
@@ -37,7 +57,7 @@ h2 {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.75rem 2rem;
-  background: #ff8c00;
+  background: var(--accent);
   color: #fff;
   text-decoration: none;
   border-radius: 4px;
@@ -46,6 +66,7 @@ h2 {
 
 .btn:hover {
   transform: scale(1.05);
+  background: var(--accent-dark);
 }
 
 .section {
@@ -62,19 +83,33 @@ h2 {
 }
 
 
-.features {
+.features,
+.cards {
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
   justify-content: space-between;
 }
 
-.feature {
+.feature,
+.card {
   flex: 1 1 250px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  border-top: 4px solid var(--accent);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.feature:hover {
+.feature img,
+.card img {
+  width: 80px;
+  margin-bottom: 1rem;
+}
+
+.feature:hover,
+.card:hover {
   transform: translateY(-5px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
@@ -85,7 +120,7 @@ h2 {
 }
 
 .cta .btn {
-  background: #0077cc;
+  background: var(--accent);
 }
 
 .footer {
@@ -122,6 +157,13 @@ h2 {
   flex: 1;
 }
 
+.order-img {
+  flex: 1;
+  max-width: 400px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
 .fixed-illust {
   position: fixed;
   bottom: 0;
@@ -144,5 +186,48 @@ h2 {
   .fixed-illust {
     width: 220px;   /* スマホは小さめ */
   }
+
+  .about {
+    flex-direction: column;
+  }
+
+  .order-layout {
+    flex-direction: column;
+  }
+
+  .features,
+  .cards {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .section {
+    padding: 60px 0;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+  }
+}
+
+.about {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2rem;
+}
+
+.about-img {
+  width: 100%;
+  max-width: 500px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.reviews-photo {
+  width: 150px;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 2rem;
 }
 


### PR DESCRIPTION
## 概要
- 画像をレスポンシブ化してスマホでも崩れないよう調整
- Featureとラインナップを共通カード化し、モバイルでは縦並びになるようにしたよ
- モバイル画面の余白や見出しサイズを調整して読みやすさアップ

## テスト
- `npm test`: package.json が無いため実行できず

------
https://chatgpt.com/codex/tasks/task_e_688f7cd151708330b160900c62b93bf8