### PR TITLE
モバイル表示を調整してスマホ対応を改善

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,46 @@ h2::after {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+.brewer {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.brewer-photo {
+  width: 100%;
+  max-width: 400px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.card {
+  flex: 1 1 250px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  border-top: 4px solid var(--accent);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card img {
+  width: 80px;
+  margin-bottom: 1rem;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
 .fixed-illust {
   position: fixed;
   bottom: 0;
@@ -178,12 +218,16 @@ h2::after {
     width: 220px;   /* スマホは小さめ */
   }
 
-  .about {
+  .about,
+  .order-layout,
+  .brewer {
     flex-direction: column;
+    text-align: center;
   }
 
-  .order-layout {
+  .cards {
     flex-direction: column;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## 概要
- ブルワー紹介と商品のカードをCSSでレイアウト化
- スマホ幅で各セクションが縦並びになるようメディアクエリを追加

## テスト
- `npm test` は `package.json` が無くて実行不可

------
https://chatgpt.com/codex/tasks/task_e_688f80fee7088330aa621b29b5a14303