### PR TITLE
fix: adjust beer images for responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,11 @@ body {
   color: #333;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 :root {
   --accent: #ff6b6b;
   --accent-dark: #ff4757;
@@ -186,8 +191,10 @@ h2::after {
 }
 
 .card img {
-  width: 80px;
-  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 150px;
+  height: auto;
+  margin: 0 auto 1rem;
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
- make all images scale within their containers to avoid overflow
- resize and center beer card images for consistent display on any screen

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f82dd22f08330b2e7f9db90bfcade